### PR TITLE
fix: Separate scramble and solve functionality

### DIFF
--- a/index.html
+++ b/index.html
@@ -597,9 +597,8 @@
                 applyMove(randomMove);
             }
 
-            // Directly call startSolving, which will now see the scrambled state
             updateCubeDisplay();
-            startSolving();
+            showMessage("Cube has been scrambled. Click 'Start Solving' to begin.", 3000);
         }
 
         function updateNavigationButtons() {


### PR DESCRIPTION
The `scrambleCubeAndSolve` function was previously scrambling the cube and immediately attempting to solve it, causing a logic error where the application would incorrectly report that the cube was already solved.

This commit modifies the function to only perform the scramble. You are then prompted to click the 'Start Solving' button to begin the solution process. This separation of concerns resolves the bug and provides a more intuitive user experience.